### PR TITLE
Upgrad Fixie to 3.0.0-beta.1

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fixie.console": {
-      "version": "3.0.0-alpha.3",
+      "version": "3.0.0-beta.1",
       "commands": [
         "fixie"
       ]

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
-        <FixieVersion>3.0.0-alpha.3</FixieVersion>
+        <FixieVersion>3.0.0-beta.1</FixieVersion>
         <ShouldlyVersion>3.0.2</ShouldlyVersion>
     </PropertyGroup>
 </Project>

--- a/src/Fixie.Integration/MethodInfoExtensions.cs
+++ b/src/Fixie.Integration/MethodInfoExtensions.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fixie.Integration
+{
+    public static class MethodInfoExtensions
+    {
+        public static object Execute(this MethodInfo method, object instance, params object[] parameters)
+        {
+            object result;
+
+            try
+            {
+                result = method.Invoke(instance, parameters != null && parameters.Length == 0 ? null : parameters);
+            }
+            catch (TargetInvocationException exception)
+            {
+                ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
+                throw; //Unreachable.
+            }
+
+            if (result == null)
+                return null;
+
+            if (!ConvertibleToTask(result, out var task))
+                return result;
+
+            task.GetAwaiter().GetResult();
+
+            if (method.ReturnType.IsGenericType)
+            {
+                var property = task.GetType().GetProperty("Result", BindingFlags.Instance | BindingFlags.Public);
+
+                return property.GetValue(task, null);
+            }
+
+            return null;
+        }
+
+        static bool ConvertibleToTask(object result, out Task task)
+        {
+            if (result is Task t)
+            {
+                task = t;
+                return true;
+            }
+
+            task = null;
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
### CLI Build test.
```
.\build.ps1

dotnet tool restore
Tool 'fixie.console' (version '3.0.0-beta.1') was restored. Available commands: fixie

Restore was successful.

dotnet clean src -c Release --nologo -v minimal

dotnet build src -c Release --nologo
  Determining projects to restore...
  Restored H:\open-source\fixie.integration\src\Fixie.Integration\Fixie.Integration.csproj (in 304 ms).
  Restored H:\open-source\fixie.integration\src\xUnitStyle.Tests\xUnitStyle.Tests.csproj (in 304 ms).
  Restored H:\open-source\fixie.integration\src\NUnitStyle.Tests\NUnitStyle.Tests.csproj (in 304 ms).
  Restored H:\open-source\fixie.integration\src\FSharp.Tests\FSharp.Tests.fsproj (in 304 ms).
  Restored H:\open-source\fixie.integration\src\CustomConvention.Tests\CustomConvention.Tests.csproj (in 304 ms).
  Restored H:\open-source\fixie.integration\src\DefaultConvention.Tests\DefaultConvention.Tests.csproj (in 304 ms).
  Fixie.Integration -> H:\open-source\fixie.integration\src\Fixie.Integration\bin\Release\netcoreapp3.1\Fixie.Integration.dll
  DefaultConvention.Tests -> H:\open-source\fixie.integration\src\DefaultConvention.Tests\bin\Release\netcoreapp3.1\DefaultConvention.Tests.dll
  xUnitStyle.Tests -> H:\open-source\fixie.integration\src\xUnitStyle.Tests\bin\Release\netcoreapp3.1\xUnitStyle.Tests.dll
  CustomConvention.Tests -> H:\open-source\fixie.integration\src\CustomConvention.Tests\bin\Release\netcoreapp3.1\CustomConvention.Tests.dll
  NUnitStyle.Tests -> H:\open-source\fixie.integration\src\NUnitStyle.Tests\bin\Release\netcoreapp3.1\NUnitStyle.Tests.dll
  FSharp.Tests -> H:\open-source\fixie.integration\src\FSharp.Tests\bin\Release\netcoreapp3.1\FSharp.Tests.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:12.72

dotnet fixie CustomConvention.Tests -c Release --no-build
Running CustomConvention.Tests

.ctor
SetUp
ShouldSubtract
TearDown
Dispose

.ctor
SetUp
ShouldAdd
TearDown
Dispose

.ctor
SetUp
ShouldSubtract
TearDown
Dispose

.ctor
Dispose

.ctor
SetUp
ShouldInferGenericTypes<System.Int32>(1, 2, System.Int32)
ShouldInferGenericTypes<System.Int64>(2, 4, System.Int64)
TearDown
Dispose

.ctor
SetUp
ShouldFail
Test 'CustomConvention.Tests.CalculatorTests.ShouldFail' failed:

This test is written to fail, to demonstrate failure reporting.

System.Exception
   at CustomConvention.Tests.CalculatorTests.ShouldFail() in H:\open-source\fixie.integration\src\CustomConvention.Tests\CalculatorTests.cs:line 56

TearDown
Dispose

.ctor
SetUp
ShouldAdd
TearDown
Dispose

.ctor
SetUp
ShouldAdd(2, 3, 5)
ShouldAdd(3, 5, 8)
TearDown
Dispose

Test 'CustomConvention.Tests.CalculatorTests.ShouldBeSkipped' skipped:
This test did not run.

.ctor
ShouldReceiveFakeThirdPartyService
Dispose

.ctor
ShouldReceiveRealDatabase
Dispose

10 passed, 1 failed, 1 skipped, took 0.07 seconds


dotnet fixie DefaultConvention.Tests -c Release --no-build
Running DefaultConvention.Tests

.ctor
ShouldAdd
Dispose

.ctor
ShouldSubtract
Dispose

.ctor
ShouldAdd
Dispose

.ctor
ShouldSubtract
Dispose

.ctor
ShouldFail
Dispose

Test 'DefaultConvention.Tests.CalculatorTests.ShouldFail' failed:

This test is written to fail, to demonstrate failure reporting.

System.Exception
   at DefaultConvention.Tests.CalculatorTests.ShouldFail() in H:\open-source\fixie.integration\src\DefaultConvention.Tests\CalculatorTests.cs:line 31

ChildTest
BaseTest
ChildTest
BaseTest
.ctor
ShouldAdd
Dispose

.ctor
ShouldSubtract
Dispose

13 passed, 1 failed, took 0.81 seconds


dotnet fixie FSharp.Tests -c Release --no-build
Running FSharp.Tests

Test 'FSharp.Tests.AsyncTests.Should Support Failing Async<T> Tests' failed:

This test is written to fail, to demonstrate async test case execution.

System.Exception
   at FSharp.Tests.AsyncTests.Should Support Failing Async<T> Tests@21-3.Invoke(String _arg1) in H:\open-source\fixie.integration\src\FSharp.Tests\AsyncTests.fs:line 21
   at Microsoft.FSharp.Control.AsyncPrimitives.CallThenInvokeNoHijackCheck[a,b](AsyncActivation`1 ctxt, FSharpFunc`2 userCode, b result1) in F:\workspace\_work\1\s\src\fsharp\FSharp.Core\async.fs:line 417
   at FSharp.Tests.AsyncTests.Should Support Failing Async<T> Tests@20-2.Invoke(AsyncActivation`1 ctxt) in H:\open-source\fixie.integration\src\FSharp.Tests\AsyncTests.fs:line 20
   at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc`2 firstAction) in F:\workspace\_work\1\s\src\fsharp\FSharp.Core\async.fs:line 109
--- End of stack trace from previous location where exception was thrown ---

Test 'FSharp.Tests.AsyncTests.Should Support Failing Task<T> Tests' failed:

This test is written to fail, to demonstrate async test case execution.

System.Exception
   at FSharp.Tests.AsyncTests.Should Support Failing Task<T> Tests@27-3.Invoke(String _arg1) in H:\open-source\fixie.integration\src\FSharp.Tests\AsyncTests.fs:line 27
   at Microsoft.FSharp.Control.AsyncPrimitives.CallThenInvokeNoHijackCheck[a,b](AsyncActivation`1 ctxt, FSharpFunc`2 userCode, b result1) in F:\workspace\_work\1\s\src\fsharp\FSharp.Core\async.fs:line 417
   at FSharp.Tests.AsyncTests.Should Support Failing Task<T> Tests@26-2.Invoke(AsyncActivation`1 ctxt) in H:\open-source\fixie.integration\src\FSharp.Tests\AsyncTests.fs:line 26
   at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc`2 firstAction) in F:\workspace\_work\1\s\src\fsharp\FSharp.Core\async.fs:line 109
--- End of stack trace from previous location where exception was thrown ---

4 passed, 2 failed, took 1.02 seconds


dotnet fixie *UnitStyle.Tests -c Release --no-build
Running NUnitStyle.Tests

.ctor
TestFixtureSetUp
SetUp
ShouldAdd
TearDown
SetUp
ShouldDivide
TearDown
SetUp
ShouldSubtract
TearDown
SetUp
ShouldThrowWhenDividingByZero
TearDown
TestFixtureTearDown
Dispose

.ctor
TestFixtureSetUp
SetUp
External Field: ShouldAdd(10, 20, 30)
TearDown
SetUp
External Field: ShouldAdd(20, 30, 50)
TearDown
SetUp
External Method: ShouldAdd(30, 40, 70)
TearDown
SetUp
External Method: ShouldAdd(40, 50, 90)
TearDown
SetUp
External Property: ShouldAdd(50, 60, 110)
TearDown
SetUp
External Property: ShouldAdd(60, 70, 130)
TearDown
SetUp
Internal Field: ShouldAdd(1, 2, 3)
TearDown
SetUp
Internal Field: ShouldAdd(2, 3, 5)
TearDown
SetUp
Internal Method: ShouldAdd(3, 4, 7)
TearDown
SetUp
Internal Method: ShouldAdd(4, 5, 9)
TearDown
SetUp
Internal Property: ShouldAdd(5, 6, 11)
TearDown
SetUp
Internal Property: ShouldAdd(6, 7, 13)
TearDown
TestFixtureTearDown
Dispose

16 passed, took 0.11 seconds

Running xUnitStyle.Tests

.ctor
SetFixture
   FixtureData 1
SetFixture
   DisposableFixtureData 1
ShouldSubtract
Dispose

.ctor
SetFixture
   FixtureData 1
SetFixture
   DisposableFixtureData 1
ShouldAdd
Dispose

2 passed, took 0.58 seconds
```

### Visual Studio Test Runner.
![image](https://user-images.githubusercontent.com/13510817/109388642-5ebf8b80-792e-11eb-8b2d-decca6addf12.png)
