### PR TITLE
Update build and version coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,8 @@ jobs:
     - name: .NET SDK
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '5.0.408'
+        dotnet-version: |
+          3.1
+          6.0
     - name: Build and Test
       run: pwsh ./build.ps1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,4 +16,7 @@ jobs:
           3.1
           6.0
     - name: Build and Test
+      env:
+        DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: true
+        TERM: xterm
       run: pwsh ./build.ps1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,9 @@ jobs:
         os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: .NET SDK
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: '5.0.408'
     - name: Build and Test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,6 @@
+version: '{build}'
+skip_tags: true
+image: Visual Studio 2022
+build_script:
+- pwsh: ./build
+test: off

--- a/build.ps1
+++ b/build.ps1
@@ -8,6 +8,7 @@ function step($command, $expectedReturnCode=0) {
     }
 }
 
+step { dotnet --version }
 step { dotnet tool restore }
 step { dotnet clean src -c Release --nologo -v minimal }
 step { dotnet build src -c Release --nologo }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-﻿{
-    "sdk": {
-      "version": "5.0.408",
-      "rollForward": "latestFeature"
-    }
-}

--- a/src/CustomConvention.Tests/CustomConvention.Tests.csproj
+++ b/src/CustomConvention.Tests/CustomConvention.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DefaultConvention.Tests/DefaultConvention.Tests.csproj
+++ b/src/DefaultConvention.Tests/DefaultConvention.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,5 @@
 ﻿<Project>
     <PropertyGroup>
-        <LangVersion>latest</LangVersion>
         <FixieVersion>3.2.0</FixieVersion>
         <ShouldlyVersion>3.0.2</ShouldlyVersion>
     </PropertyGroup>

--- a/src/FSharp.Tests/FSharp.Tests.fsproj
+++ b/src/FSharp.Tests/FSharp.Tests.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Fixie.Integration.sln.DotSettings
+++ b/src/Fixie.Integration.sln.DotSettings
@@ -3,4 +3,5 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/AddImportsToDeepestScope/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=TypesAndNamespaces/@EntryIndexedValue">&lt;Policy Inspect="False" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
-	<s:Boolean x:Key="/Default/Environment/UnitTesting/DisabledProviders/=VsTest/@EntryIndexedValue">False</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EUnitTestFramework_002EMigrations_002EEnableDisabledProvidersMigration/@EntryIndexedValue">True</s:Boolean>
+	</wpf:ResourceDictionary>

--- a/src/Fixie.Integration/Fixie.Integration.csproj
+++ b/src/Fixie.Integration/Fixie.Integration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <DebugType>full</DebugType>
     <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>

--- a/src/NUnitStyle.Tests/NUnitStyle.Tests.csproj
+++ b/src/NUnitStyle.Tests/NUnitStyle.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/xUnitStyle.Tests/xUnitStyle.Tests.csproj
+++ b/src/xUnitStyle.Tests/xUnitStyle.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
1. Avoid specifying LangVersion explicitly, as the default behavior ensures using the latest language version compatible with each target framework indicated in project files, so that we no longer need to update the language version when we update target frameworks.
2. The build script outputs the `dotnet --version` in effect, useful when troubleshooting unexpected behavior across build environments.
3. Remove global.json, so that we no longer pin the dotnet SDK for development-time concerns. This pinning capability is meant to be used only as-needed, and avoiding it is encouraged so that developers can leverage the latest development tools available. The SDK is meant to be backward compatible with older target frameworks. Note that the solution's TargetFramework selections do still strictly dictate versions pertaining to execution-time concerns.
4. Update actions/checkout and actions/setup-dotnet to v3.
5. The GitHub Actions build environment uses the latest patch version of each SDK Major.Minor listed, matching the intended set of TargetFramework under test.
6. All projects cross target .NET Core 3.1 and .NET 6, to give coverage to the current support window.
7. Allow `dotnet fixie` console colors to render in GitHub Actions logs (such colors can only pass through when executing on TargetFramework net6.0 or higher).
8. Add AppVeyor configuration to demonstrate integration.